### PR TITLE
fix: expense 추가 시에 id 값이 예상되지 않은 값으로 백엔드로 넘어가는 버그 수정

### DIFF
--- a/Frontend/luckeyseven/src/pages/ExpenseDialog/AddExpenseDialog.jsx
+++ b/Frontend/luckeyseven/src/pages/ExpenseDialog/AddExpenseDialog.jsx
@@ -63,7 +63,7 @@ export default function AddExpenseDialog({onClose, onSuccess}) {
         console.log('members:', members);
         setUsers(members);
         if (members.length > 0) {
-          const firstId = String(members[0].id);
+          const firstId = String(members[0].memberId);
           setForm(f => ({
             ...f,
             payerId: firstId,


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

## 📝작업 내용
- expense 추가 시에 추가가 안되는 버그 발생
`2025-06-16T15:29:17.342+09:00 ERROR 3344 --- [travel-budget] [nio-8080-exec-2] c.l.b.s.e.CustomExceptionHandler         : Exception @ POST /api/8/expense → code: MEMBER_ID_NOTFOUND, message: 회원ID를 찾을 수 없습니다., detail: 14`
- 디비 확인 결과 9번 유저로 호출한 상황이었지만, api는14번 유저로 호출이 되었다
-프론트엔드에서 팀 멤버를 받아올 때, TeamMemberDto 객체 리스트를 받게 되는데,
이 객체는 두 가지 ID를 가지고 있습니다:

id : 팀-멤버 관계(팀멤버십) 테이블의 ID

memberId : 진짜 멤버(유저)의 DB ID

문제의 코드(fetchMembers 함수)

```javascript
const firstId = String(members[0].id); // 문제 원인(팀의 ID가 들어감. not 유저 id)
setForm(f => ({
  ...f,
  payerId: firstId,
  settlerIds: [firstId]
}));
```
해당 부분 memberId로 수정.
## 🧪 테스트 여부
- [x] 테스트를 수행함

## 💬리뷰 요구사항
