### PR TITLE
fix: dashboard 탭 전환 시에 api 호출하여 fetch 할 수 있도록 프론트 코드 수정

### DIFF
--- a/Frontend/luckeyseven/src/pages/Team/TeamDashBoard.js
+++ b/Frontend/luckeyseven/src/pages/Team/TeamDashBoard.js
@@ -186,8 +186,8 @@ function TeamDashBoard() {
       }
     };
 
-    fetchData();
-  }, [teamId, budgetData, budgetInitialized, setTeamForeignCurrency]);
+      fetchData().catch(error => console.error(error))
+  }, [activeTab, budgetData, budgetInitialized, setTeamForeignCurrency]);
 
   return (
       <div className={styles.app}>
@@ -197,23 +197,27 @@ function TeamDashBoard() {
               pageHeaderData={pageHeaderData}
               onBudgetDelete={handleBudgetDelete}
           />
-          <Tabs activeTab={activeTab} setActiveTab={setActiveTab}/>
-          {activeTab === 'Overview' &&
-              <OverviewTabContent dashboardData={dashboardData}/>
-          }
-          {activeTab === 'Members' && (
-              <MembersTabContent
-                  teamCode={membersData.teamCode}
-                  teamPassword={membersData.teamPassword}
-                  members={membersData.members}
-              />
-          )}
-          {activeTab === 'Expenses' && (
-              <ExpenseList/>
-          )}
-          {activeTab === 'Settlement' && (
-              <TeamSettlementsPage/>
-          )}
+          <div className={styles.tabsWrapper}>
+            <Tabs activeTab={activeTab} setActiveTab={setActiveTab}/>
+            <div className={styles.tabContentArea}>
+              {activeTab === 'Overview' &&
+                  <OverviewTabContent dashboardData={dashboardData}/>
+              }
+              {activeTab === 'Members' && (
+                  <MembersTabContent
+                      teamCode={membersData.teamCode}
+                      teamPassword={membersData.teamPassword}
+                      members={membersData.members}
+                  />
+              )}
+              {activeTab === 'Expenses' && (
+                  <ExpenseList/>
+              )}
+              {activeTab === 'Settlement' && (
+                  <TeamSettlementsPage/>
+              )}
+            </div>
+          </div>
 
           {dialogType === 'set' && (
               <SetBudgetDialog

--- a/Frontend/luckeyseven/src/styles/Tabs.module.css
+++ b/Frontend/luckeyseven/src/styles/Tabs.module.css
@@ -1,38 +1,50 @@
-/* Tabs */
-.tabs {
-  margin-bottom: 1.25rem;
+tabsContainer {
   display: flex;
-  overflow-x: auto;
-  gap: 0.5rem; /* Add some space between buttons */
+  flex-direction: column;
+  width: 100%;
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0; /* Remove bottom margin as content will follow */
 }
 
 .tabButton {
-  padding: 0.75rem 1.5rem; /* Increased padding */
-  border: 1px solid var(--color-border); /* Add a border */
-  border-radius: 0.375rem; /* Rounded corners */
-  background-color: var(--color-background-secondary, #f9f9f9); /* Light background */
+  padding: 0.75rem 1.5rem;
+  border: 1px solid var(--color-border);
+  border-bottom: none; /* Remove bottom border */
+  border-radius: 0.375rem 0.375rem 0 0; /* Round only top corners */
+  background-color: var(--color-background-secondary, #f9f9f9);
   cursor: pointer;
   color: var(--color-text);
-  font-weight: 500; /* Slightly bolder */
+  font-weight: 500;
   font-size: clamp(0.875rem, 3vw, 1rem);
   white-space: nowrap;
-  text-decoration: none; /* Remove underline from Link component */
-  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out; /* Smooth transition */
+  text-decoration: none;
+  margin-right: 0.25rem; /* Small gap between tabs */
+  position: relative;
+  bottom: -1px; /* Overlap the bottom border of the tabs container */
+  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
 }
 
 .tabButton:hover {
-  background-color: var(--color-background-tertiary, #e9e9e9); /* Darker on hover */
-  border-color: var(--color-border-hover, #cccccc);
+  background-color: var(--color-background-tertiary, #e9e9e9);
 }
 
 .tabButtonActive {
-  border-color: var(--color-primary);
-  background-color: var(--color-primary-light, #e6f7ff); /* Lighter primary color for active background */
+  border-color: var(--color-border);
+  border-bottom: 1px solid var(--color-background, #ffffff); /* Match content background */
+  background-color: var(--color-background, #ffffff);
   color: var(--color-primary);
   font-weight: bold;
+  z-index: 1; /* Ensure active tab is above the border */
 }
 
-/* Remove bottom border from .tabs container as buttons now have their own borders */
-.tabs {
-  border-bottom: none; 
+.tabContent {
+  padding: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-top: none; /* Connect with the active tab */
+  background-color: var(--color-background, #ffffff);
+  border-radius: 0 0 0.375rem 0.375rem; /* Round bottom corners */
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

## 📝작업 내용
- dashboard 탭으로 전환 시에 fetchData 실행되게 수정
- 기존의 경우 active tab이 의존성 배열에 빠져 있어서 새로 고침이 되지 않았다. activeTab을 의존성 배열에 추가해서 fetch 되게 수정하였다.

```
      fetchData().catch(error => console.error(error))
  }, [activeTab, budgetData, budgetInitialized, setTeamForeignCurrency]);
```
이제 expense에서 지출 변경사항 발생 후 dashboard 탭으로 이동하면 변경 사항 바로 반영됩니다.
- 대시보드 의 tabs css 를 변경
  - 명칭에 맞게 버튼이 아닌 탭으로 디자인을 변경했습니다.
## 🧪 테스트 여부
- [x] 테스트를 수행함

## 💬리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?