### PR TITLE
Refactor: 정산 집계 성능 리팩토링

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,189 @@
+# .github/workflows/deploy.yml
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  EC2_HOST: ${{ secrets.EC2_HOST }}
+  EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
+  EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+  DB_URL: ${{ secrets.DB_URL }}
+  DB_USERNAME: ${{ secrets.DB_USERNAME }}
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
+  EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+  ACCESS_KEY: ${{ secrets.ACCESS_KEY}}
+  REFRESH_KEY: ${{ secrets.REFRESH_KEY }}
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # 백엔드 테스트
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./Backend/gradlew
+
+      - name: Run Backend tests
+        run: |
+          cd Backend
+          ./gradlew test
+
+      # 프론트엔드 테스트
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: Frontend/luckeyseven/package-lock.json
+
+      - name: Install Frontend dependencies
+        run: |
+          cd Frontend/luckeyseven
+          npm ci
+
+      - name: Run frontend tests
+        run: |
+          cd Frontend/luckeyseven
+          npm test -- --coverage --watchAll=false
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # 백엔드 빌드
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./Backend/gradlew
+
+      - name: Build Backend with Gradle
+        run: |
+          cd Backend
+          ./gradlew build -x test
+
+      # 프론트엔드 빌드
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: Frontend/luckeyseven/package-lock.json
+
+      - name: Install frontend dependencies
+        run: |
+          cd Frontend/luckeyseven
+          npm ci
+
+      - name: Build frontend
+        run: |
+          cd Frontend/luckeyseven
+          npm run build
+
+      # Docker Hub 로그인
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      # 환경 변수 설정
+      - name: Set environment variables
+        run: |
+          echo "DOCKER_USERNAME=${{ env.DOCKER_USERNAME }}" >> $GITHUB_ENV
+          echo "GITHUB_SHA=${{ github.sha }}" >> $GITHUB_ENV
+
+      # Docker Compose로 이미지 빌드
+      - name: Build Docker images with docker-compose
+        run: |
+          export DOCKER_USERNAME=${{ env.DOCKER_USERNAME }}
+          export GITHUB_SHA=${{ github.sha }}
+          export COMPOSE_BAKE=true
+          docker compose build
+
+      # 이미지에 latest 태그 추가 및 Docker Hub에 푸시
+      - name: Tag and push images to Docker Hub
+        run: |
+          docker compose push
+          
+          docker tag ${{ env.DOCKER_USERNAME }}/tem-backend:${{ github.sha }} ${{ env.DOCKER_USERNAME }}/tem-backend:latest
+          docker tag ${{ env.DOCKER_USERNAME }}/tem-frontend:${{ github.sha }} ${{ env.DOCKER_USERNAME }}/tem-frontend:latest
+          
+          docker push ${{ env.DOCKER_USERNAME }}/tem-backend:latest
+          docker push ${{ env.DOCKER_USERNAME }}/tem-frontend:latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Copy docker-compose-server.yml to EC2
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ env.EC2_HOST }}
+          username: ${{ env.EC2_USERNAME }}
+          key: ${{ env.EC2_SSH_KEY }}
+          source: "docker-compose-server.yml"
+          target: "/home/ubuntu/"
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ env.EC2_HOST }}
+          username: ${{ env.EC2_USERNAME }}
+          key: ${{ env.EC2_SSH_KEY }}
+          script: |
+            echo "Deploying to EC2 instance..."
+            echo "make environment variables"
+            export DOCKER_USERNAME="${{ env.DOCKER_USERNAME }}"
+            export DB_URL="${{ env.DB_URL }}"
+            export DB_USERNAME="${{ env.DB_USERNAME }}"
+            export DB_PASSWORD="${{ env.DB_PASSWORD }}"
+            export MAIL_USERNAME="${{ env.MAIL_USERNAME}}"
+            export MAIL_PASSWORD="${{ env.MAIL_PASSWORD}}"
+            export ACCESS_KEY="${{ env.ACCESS_KEY }}"
+            export REFRESH_KEY="${{ env.REFRESH_KEY }}"
+            
+            # 기존 컨테이너 중지 및 제거
+            echo "Stopping and removing existing containers..."
+            sudo docker compose -f docker-compose-server.yml down || true
+            
+            # 최신 이미지 풀
+            echo "Pulling latest Docker images..."
+            sudo docker pull ${{ env.DOCKER_USERNAME }}/tem-backend:latest
+            sudo docker pull ${{ env.DOCKER_USERNAME }}/tem-frontend:latest
+            
+            
+            
+            # Docker Compose로 애플리케이션 실행
+            echo "Starting application with Docker Compose..."
+            sudo docker compose -f docker-compose-server.yml up -d
+            
+            # 사용하지 않는 이미지 정리
+            echo "Cleaning up unused Docker images..."
+            sudo docker image prune -f

--- a/Backend/src/main/kotlin/com/luckyseven/backend/BackendApplication.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/BackendApplication.kt
@@ -8,8 +8,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 @EnableJpaAuditing
 @EnableCaching
 @SpringBootApplication
-@EnableJpaAuditing
-@EnableCaching
 class BackendApplication
 
 fun main(args: Array<String>) {

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/app/SettlementService.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/app/SettlementService.kt
@@ -160,7 +160,7 @@ class SettlementService(
                 } else if (amountSum[i][j] > amountSum[j][i]) {
                     sumList.add(
                         SettlementMemberAggregationResponse(
-                            from = memberIds[1]!!,
+                            from = memberIds[i]!!,
                             to = memberIds[j]!!,
                             amount = amountSum[i][j] - amountSum[j][i]
                         )

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/app/SettlementService.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/app/SettlementService.kt
@@ -174,9 +174,11 @@ class SettlementService(
     @Transactional
     fun settleBetweenMembers(teamId: Long, from: Long, to: Long) {
         //TODO: 쿼리튜닝으로 개선하기
-        val settlements = settlementRepository.findAllByTeamId(teamId).filter { it ->
-            (it.settler.id == from && it.payer.id == to) || (it.settler.id == to && it.payer.id == from)
-        }.forEach { it.isSettled = true }
+        val settlements = settlementRepository.findAllByTeamId(teamId).use { stream ->
+            stream
+                .filter { it -> (it.settler.id == from && it.payer.id == to) || (it.settler.id == to && it.payer.id == from) }
+                .forEach { it.isSettled = true }
+        }
 
     }
 }

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/app/SettlementService.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/app/SettlementService.kt
@@ -173,13 +173,9 @@ class SettlementService(
 
     @Transactional
     fun settleBetweenMembers(teamId: Long, from: Long, to: Long) {
-        //TODO: 쿼리튜닝으로 개선하기
-        val settlements = settlementRepository.findAllByTeamId(teamId).use { stream ->
-            stream
-                .filter { it -> (it.settler.id == from && it.payer.id == to) || (it.settler.id == to && it.payer.id == from) }
-                .forEach { it.isSettled = true }
+        settlementRepository.findAssociatedNotSettled(teamId, from, to).use { stream ->
+            stream.forEach { it.isSettled = true }
         }
-
     }
 }
 

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/dao/SettlementRepository.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/dao/SettlementRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.util.stream.Stream
 
 @Repository
 interface SettlementRepository : JpaRepository<Settlement, Long>,
@@ -14,6 +15,7 @@ interface SettlementRepository : JpaRepository<Settlement, Long>,
     @EntityGraph(attributePaths = ["settler", "payer"])
     fun findWithSettlerAndPayerById(id: Long): Settlement?
 
-    @Query("SELECT s From Settlement s join s.expense e where e.team.id = :teamId")
-    fun findAllByTeamId(teamId: Long): List<Settlement>
+    @EntityGraph(attributePaths = ["settler", "payer"])
+    @Query("SELECT s From Settlement s join s.expense e where e.team.id = :teamId and s.isSettled = false")
+    fun findAllByTeamId(teamId: Long): Stream<Settlement>
 }

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/dao/SettlementRepository.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/dao/SettlementRepository.kt
@@ -1,10 +1,8 @@
 package com.luckyseven.backend.domain.settlement.dao
 
 import com.luckyseven.backend.domain.settlement.entity.Settlement
-import org.springframework.data.jpa.repository.EntityGraph
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor
-import org.springframework.data.jpa.repository.Query
+import jakarta.persistence.QueryHint
+import org.springframework.data.jpa.repository.*
 import org.springframework.stereotype.Repository
 import java.util.stream.Stream
 
@@ -17,5 +15,6 @@ interface SettlementRepository : JpaRepository<Settlement, Long>,
 
     @EntityGraph(attributePaths = ["settler", "payer"])
     @Query("SELECT s From Settlement s join s.expense e where e.team.id = :teamId and s.isSettled = false")
+    @QueryHints(QueryHint(name = "org.hibernate.fetchSize", value = "-2147483648"))
     fun findAllByTeamId(teamId: Long): Stream<Settlement>
 }

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/dao/SettlementRepository.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/settlement/dao/SettlementRepository.kt
@@ -17,4 +17,12 @@ interface SettlementRepository : JpaRepository<Settlement, Long>,
     @Query("SELECT s From Settlement s join s.expense e where e.team.id = :teamId and s.isSettled = false")
     @QueryHints(QueryHint(name = "org.hibernate.fetchSize", value = "-2147483648"))
     fun findAllByTeamId(teamId: Long): Stream<Settlement>
+
+    @Query(
+        "SELECT s FROM Settlement s " +
+                "WHERE s.expense.team.id = :teamId " +
+                "AND ((s.payer.id = :from AND s.settler.id = :to) " +
+                "OR (s.payer.id = :to AND s.settler.id = :from))"
+    )
+    fun findAssociatedNotSettled(teamId: Long, from: Long, to: Long): Stream<Settlement>
 }

--- a/Backend/src/main/resources/application-prod.yml
+++ b/Backend/src/main/resources/application-prod.yml
@@ -1,0 +1,48 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&autoReconnect=true
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 100
+    hibernate:
+      ddl-auto: validate
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+  jwt:
+    key:
+      AccessKey: ${ACCESS_KEY}
+      RefreshKey: ${REFRESH_KEY}
+logging:
+  level:
+    org.springframework.security: TRACE
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+      base-path: /actuator
+
+  endpoint:
+    health:
+      show-details: always
+
+  prometheus:
+    metrics:
+      export:
+        enabled: true

--- a/Backend/src/main/resources/application-ref.yml
+++ b/Backend/src/main/resources/application-ref.yml
@@ -16,7 +16,7 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url:
+    url: 경로?rewriteBatchedStatements=true # batch 설정
     username:
     password:
 
@@ -25,6 +25,8 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        jdbc:
+          batch_size: 10
     hibernate:
       ddl-auto: create
 

--- a/Backend/src/test/kotlin/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.kt
+++ b/Backend/src/test/kotlin/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.kt
@@ -11,6 +11,7 @@ import com.luckyseven.backend.domain.settlement.dao.SettlementRepository
 import com.luckyseven.backend.domain.settlement.dto.SettlementSearchCondition
 import com.luckyseven.backend.domain.settlement.dto.SettlementUpdateRequest
 import com.luckyseven.backend.domain.settlement.entity.Settlement
+import com.luckyseven.backend.domain.team.dto.TeamMemberDto
 import com.luckyseven.backend.domain.team.entity.Team
 import com.luckyseven.backend.domain.team.service.TeamMemberService
 import com.luckyseven.backend.sharedkernel.exception.CustomLogicException
@@ -23,6 +24,7 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
+import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -34,6 +36,7 @@ import org.springframework.data.jpa.domain.Specification
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.*
+import java.util.stream.Stream
 
 @ExtendWith(MockKExtension::class)
 class SettlementServiceTest {
@@ -49,6 +52,9 @@ class SettlementServiceTest {
 
     @MockK
     private lateinit var expenseRepository: ExpenseRepository
+
+    @MockK
+    private lateinit var em: EntityManager
 
     @InjectMockKs
     private lateinit var settlementService: SettlementService
@@ -232,5 +238,138 @@ class SettlementServiceTest {
             settlementService.settleSettlement(nonExistingId)
         }
         exception.exceptionCode shouldBe ExceptionCode.SETTLEMENT_NOT_FOUND
+    }
+
+    @Test
+    @DisplayName("팀 내 정산 집계 조회")
+    fun getSettlementsAggregation_ShouldReturnAggregation() {
+        // given
+        val teamId = 1L
+        val member1 =
+            Member(id = 1L, email = "member1@test.com", password = "password", nickname = "member1")
+        val member2 =
+            Member(id = 2L, email = "member2@test.com", password = "password", nickname = "member2")
+        val member3 =
+            Member(id = 3L, email = "member3@test.com", password = "password", nickname = "member3")
+
+
+        // 팀 멤버 목록 설정
+        every { teamMemberService.getTeamMemberByTeamId(teamId) } returns listOf(
+            TeamMemberDto(
+                id = 1L,
+                teamId = 2L,
+                teamName = "team1",
+                memberId = member1.id,
+                memberNickName = member1.nickname,
+                memberEmail = member1.email,
+                role = "leader"
+            ),
+            TeamMemberDto(
+                id = 2L,
+                teamId = 2L,
+                teamName = "team1",
+                memberId = member2.id,
+                memberNickName = member2.nickname,
+                memberEmail = member2.email,
+                role = "member"
+            ),
+            TeamMemberDto(
+                id = 3L,
+                teamId = 2L,
+                teamName = "team1",
+                memberId = member3.id,
+                memberNickName = member3.nickname,
+                memberEmail = member3.email,
+                role = "member"
+            )
+        )
+
+        // 정산 데이터 설정
+        val settlement1 = Settlement(
+            id = 1L,
+            amount = BigDecimal.valueOf(1000),
+            settler = member1,
+            payer = member2,
+            expense = expense,
+            isSettled = false
+        )
+        val settlement2 = Settlement(
+            id = 2L,
+            amount = BigDecimal.valueOf(500),
+            settler = member2,
+            payer = member1,
+            expense = expense,
+            isSettled = false
+        )
+        val settlement3 = Settlement(
+            id = 3L,
+            amount = BigDecimal.valueOf(300),
+            settler = member3,
+            payer = member1,
+            expense = expense,
+            isSettled = false
+        )
+
+        val settlementStream = Stream.of(settlement1, settlement2, settlement3)
+        every { settlementRepository.findAllByTeamId(teamId) } returns settlementStream
+        every { em.clear() } returns Unit
+
+        // when
+        val result = settlementService.getSettlementsAggregation(teamId)
+
+        // then
+        result.aggregations.isNotEmpty() shouldBe true
+        result.aggregations.find { it.from == member1.id && it.to == member2.id }?.amount shouldBe BigDecimal.valueOf(
+            500
+        )
+        result.aggregations.find { it.from == member3.id && it.to == member1.id }?.amount shouldBe BigDecimal.valueOf(
+            300
+        )
+        result.aggregations.any { it.amount > BigDecimal.ZERO } shouldBe true
+    }
+
+    @Test
+    @DisplayName("멤버 간 정산 일괄처리")
+    fun settleBetweenMembers_ShouldMarkSettlementsAsSettled() {
+        // given
+        val teamId = 1L
+        val fromMemberId = 1L
+        val toMemberId = 2L
+
+        val settlement1 = Settlement(
+            id = 1L,
+            amount = BigDecimal.valueOf(1000),
+            settler = settler,
+            payer = payer,
+            expense = expense,
+            isSettled = false
+        )
+        val settlement2 = Settlement(
+            id = 2L,
+            amount = BigDecimal.valueOf(500),
+            settler = settler,
+            payer = payer,
+            expense = expense,
+            isSettled = false
+        )
+
+        val settlementStream = Stream.of(settlement1, settlement2)
+        every {
+            settlementRepository.findAssociatedNotSettled(
+                teamId,
+                fromMemberId,
+                toMemberId
+            )
+        } returns settlementStream
+        every { em.flush() } returns Unit
+
+        // when
+        settlementService.settleBetweenMembers(teamId, fromMemberId, toMemberId)
+
+        // then
+        // 모든 정산이 완료 상태로 변경되었는지 확인
+        settlement1.isSettled shouldBe true
+        settlement2.isSettled shouldBe true
+        verify { em.flush() }
     }
 }

--- a/Backend/src/test/kotlin/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.kt
+++ b/Backend/src/test/kotlin/com/luckyseven/backend/domain/settlements/app/SettlementServiceTest.kt
@@ -361,8 +361,6 @@ class SettlementServiceTest {
                 toMemberId
             )
         } returns settlementStream
-        every { em.flush() } returns Unit
-
         // when
         settlementService.settleBetweenMembers(teamId, fromMemberId, toMemberId)
 
@@ -370,6 +368,5 @@ class SettlementServiceTest {
         // 모든 정산이 완료 상태로 변경되었는지 확인
         settlement1.isSettled shouldBe true
         settlement2.isSettled shouldBe true
-        verify { em.flush() }
     }
 }

--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -1,0 +1,33 @@
+# docker-compose-server.yml (운영 서버용)
+
+services:
+  backend:
+    image: ${DOCKER_USERNAME}/tem-backend:latest
+    container_name: backend
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - DB_URL=${DB_URL}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - MAIL_USERNAME=${MAIL_USERNAME}
+      - MAIL_PASSWORD=${MAIL_PASSWORD}
+      - ACCESS_KEY=${ACCESS_KEY}
+      - REFRESH_KEY=${REFRESH_KEY}
+      - SERVER_PORT=8080
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  frontend:
+    image: ${DOCKER_USERNAME}/tem-frontend:latest
+    container_name: frontend
+    ports:
+      - "3000:80"
+    networks:
+      - app-network
+    restart: unless-stopped
+networks:
+  app-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# docker-compose.build.yml (빌드 전용 - 선택사항)
+
+services:
+  backend:
+    build:
+      context: ./Backend
+      dockerfile: Dockerfile
+    image: ${DOCKER_USERNAME}/tem-backend:${GITHUB_SHA:-latest}
+
+  frontend:
+    build:
+      context: ./Frontend/luckeyseven
+      dockerfile: Dockerfile
+    image: ${DOCKER_USERNAME}/tem-frontend:${GITHUB_SHA:-latest}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- Cloeses: #49 

## 📝작업 내용
# 집계 성능 개선
- 특정 팀에서 특정 멤버쌍간 보내야 하는 금액을 양방향으로 계산하여 집계해주는 기능

**테스트 진행 방식**

- 애플리케이션 실행후 3분 이상 대기
- 테스트 시작후 1000건의 요청으로 워밍업
- 가상유저수
    - 10초간 중가하여 10명에서 30초
    - 10초간 증가하여 30명에서 30초
    - 10초간 증가하여 50명에서 2분
    - 20초간 감소하여 0명에서 종료
- 통계는 50명 2분 스테이지에서만 산출

### 기존 성능 테스트 결과

- 응답시간: 48ms
- Heap 사용량 5.46%
- 메모리 사용량: 1.01 GiB

![1](https://github.com/user-attachments/assets/c007c907-4a6c-4e62-abff-77ae42c55bfb)
![2](https://github.com/user-attachments/assets/05795fb7-8b5e-467e-97a5-8282c5fb2566)
![3](https://github.com/user-attachments/assets/59386535-8a8c-47f8-b6a7-f8f65a340762)

## 성능개선

**개선 목록**

- 리스트 indexOf → 맵 사용
- 데이터 List로 전체로딩 → JPA Stream
- 영속성 컨텍스트 전체 유지 → 주기적으로 clear
- 정산 연관 멤버 지연로딩 → EntityGraph활용 fetchjoin

### 개선 성능테스트 결과

- 응답시간: 60ms
- Heap 사용량 2.7%
- 메모리 사용량: 800 MiB

![1](https://github.com/user-attachments/assets/19bdf324-fa51-426b-b691-f4a999b295f1)
![2](https://github.com/user-attachments/assets/e7e9155b-456f-4cdc-969f-88a57e5da46f)
![3](https://github.com/user-attachments/assets/a3ca6364-e0bf-48ff-97e8-868df6336e21)

## 결론
- 힙사용량이 약 50% 감소 (5.46% -> 2.7%)
- 메모리 사용량 약 20% 감소 (1.01 GiB -> 800MiB)
- 응답시간 약 20% 증가 (48ms -> 60ms)

스트림 처리 및 영속성 컨텍스트 clear 작업으로 인해 작업시간이 길어졌으나 그 차이가 크지 않고
그에 반해 큰 메모리 효율성을 챙길 수 있었음

# 일괄 처리 성능 개선
- 특정 팀에서 두 사람간의 모든 정산을 완료 처리하는 기능
- 동일한 환경에서 요청의 부하가 큼을 고려해 웜업 요청을 100건으로 줄였다.
- 테스트를 위해 롤백처리가 포함되었으며 일반적이지 않은 양의 데이터를 처리하여 응답 시간이 매우 커짐을 고려

### 기존 성능 테스트 결과
- 응답시간: 점점 증가하여 28초에서 유지
- Heap 사용량: 5.42%
- 메모리 사용량: 1.2GiB
![1](https://github.com/user-attachments/assets/04d85529-c39d-4ba2-8fa7-bfb99333a8a8)
![2](https://github.com/user-attachments/assets/f3a02436-8b77-44f1-822b-7e19ee81a4f9)
![3](https://github.com/user-attachments/assets/33847b07-8eb0-4374-8e5b-a7d67aa493f8)

## 성능 개선
- Batch Update를 통해 개선을 시도
- Batch-size를 10, 20, 50, 100 으로 시도하였으며 가장 성능이 좋았던 100만 업로드
### 개선 성능 테스트 결과
- 응답시간: 점점 증가하여 3.76초에서 유지
- Heap 사용량: 4.52%
- 메모리 사용량: 384MiB
![1](https://github.com/user-attachments/assets/2f85c053-32bc-4735-8afd-b6d81658270a)
![2](https://github.com/user-attachments/assets/be9d3154-6ddd-4669-bfdd-b508c39e9b93)
![3](https://github.com/user-attachments/assets/b5827713-4670-49a0-8e2c-2d12bf40a194)

## 결론
- 응답시간 약 85%감소 (27.8s -> 3.76s)
- 메모리 사용량 약 70% 감소 (1.2GiB -> 380MiB)
- 힙 사용량은 유지

배치처리를 활용하여 응답시간과 메모리 사용량을 매우 크게 개선할 수 있었다.
매우 많은 데이터양과, 롤백 기능이 포함되어 있어 여전히 응답시간이 길게 나왔지만
일반적인 케이스에서 수천건의 정산이 한번에 업데이트 될 일은 사실상 없기 때문에 충분히 납득할 수 있는 성능이 측정되었다고 할 수 있다.

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항
힘드네요