### PR TITLE
refactor: 팀 삭제 전략 변경 및 해당 변경에 맞추어 팀 setup 뷰 수정

### DIFF
--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/controller/TeamController.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/controller/TeamController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import lombok.`val`
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.ErrorResponse
@@ -213,7 +212,7 @@ class TeamController(
         return ResponseEntity.ok(dashboardResponse)
     }
 
-    @PostMapping("/{teamId}/    delete")
+    @PostMapping("/{teamId}/delete")
     fun markTeamForDeletion(
         @AuthenticationPrincipal memberDetails: MemberDetails,
         @PathVariable teamId: Long

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/controller/TeamController.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/controller/TeamController.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import lombok.`val`
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.ErrorResponse
@@ -210,6 +211,15 @@ class TeamController(
         val dashboardResponse = teamService.getTeamDashboard(teamId)
 
         return ResponseEntity.ok(dashboardResponse)
+    }
+
+    @PostMapping("/{teamId}/    delete")
+    fun markTeamForDeletion(
+        @AuthenticationPrincipal memberDetails: MemberDetails,
+        @PathVariable teamId: Long
+    ): ResponseEntity<Void> {
+        teamService.markTeamForDeletion(memberDetails, teamId)
+        return ResponseEntity.noContent().build()
     }
 }
 

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/entity/Team.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/entity/Team.kt
@@ -3,9 +3,11 @@ package com.luckyseven.backend.domain.team.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.luckyseven.backend.domain.budget.entity.Budget
 import com.luckyseven.backend.domain.member.entity.Member
+import com.luckyseven.backend.domain.team.enums.TeamStatus
 import com.luckyseven.backend.sharedkernel.entity.BaseEntity
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(
@@ -35,6 +37,12 @@ class Team(
 
     @Column(nullable = false)
     var teamPassword: String,
+
+    @Enumerated(EnumType.STRING)
+    var status: TeamStatus = TeamStatus.ACTIVE,
+
+    var deletionScheduledAt: LocalDateTime? = null,
+
 
     /**
      * 팀장 ID

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/enums/TeamStatus.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/enums/TeamStatus.kt
@@ -1,0 +1,7 @@
+package com.luckyseven.backend.domain.team.enums
+
+enum class TeamStatus {
+    ACTIVE,
+    MARKED_FOR_DELETE,
+    DELETED
+}

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/repository/TeamRepository.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/repository/TeamRepository.kt
@@ -1,15 +1,19 @@
-    package com.luckyseven.backend.domain.team.repository
+package com.luckyseven.backend.domain.team.repository
 
-    import com.luckyseven.backend.domain.team.entity.Team
-    import org.springframework.data.jpa.repository.JpaRepository
-    import org.springframework.data.jpa.repository.Query
-    import org.springframework.data.repository.query.Param
-    import org.springframework.stereotype.Repository
+import com.luckyseven.backend.domain.team.entity.Team
+import com.luckyseven.backend.domain.team.enums.TeamStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
-    @Repository
-    interface TeamRepository : JpaRepository<Team, Long> {
-        fun findByTeamCode(teamCode: String): Team?
+@Repository
+interface TeamRepository : JpaRepository<Team, Long> {
+    fun findByTeamCode(teamCode: String): Team?
 
-        @Query("select t from Team t join fetch t.budget where t.id = :teamId")
-        fun findTeamWithBudget(@Param("teamId") teamId: Long): Team?
-    }
+    @Query("select t from Team t join fetch t.budget where t.id = :teamId")
+    fun findTeamWithBudget(@Param("teamId") teamId: Long): Team?
+
+    fun findByStatusAndDeletionScheduledAt(status: TeamStatus, deletionScheduledAt: LocalDateTime): List<Team>
+}

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/service/TeamDeletionScheduler.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/service/TeamDeletionScheduler.kt
@@ -1,0 +1,12 @@
+package com.luckyseven.backend.domain.team.service
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class TeamDeletionScheduler(private val teamService: TeamService) {
+    @Scheduled(cron = "0 0 0 * * ?")
+    fun processTeamDeletion() {
+        teamService.deleteMarkedTeams()
+    }
+}

--- a/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/service/TeamService.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/domain/team/service/TeamService.kt
@@ -227,7 +227,6 @@ class TeamService(
         team.status = TeamStatus.MARKED_FOR_DELETE
         team.deletionScheduledAt = LocalDateTime.now().plusDays(14)
         teamRepository.save(team)
-
     }
 
     @Transactional

--- a/Frontend/luckeyseven/src/service/TeamService.js
+++ b/Frontend/luckeyseven/src/service/TeamService.js
@@ -59,7 +59,7 @@ export const getTeamDashboard = async (teamId) => {
   
   export const deleteTeam = async (teamId) => {
     try {
-      const response = await privateApi.delete(`/api/teams/${teamId}`);
+      const response = await privateApi.post(`/api/teams/${teamId}/delete`);
       return response.data;
     } catch (error) {
       console.error('Error deleting team:', error);

--- a/Frontend/luckeyseven/src/styles/TeamSetup.module.css
+++ b/Frontend/luckeyseven/src/styles/TeamSetup.module.css
@@ -180,3 +180,45 @@
 .teamCard:last-child {
   margin-bottom: 0;
 }
+
+
+/* 팀 카드에 상대적 위치 지정 */
+.teamCard {
+  width: 100%;
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: 5px;
+  background-color: var(--color-card);
+  text-align: center;
+  margin-bottom: var(--space-md);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+  position: relative; /* 추가: 삭제 버튼의 절대 위치 지정을 위함 */
+}
+
+/* 삭제 버튼 스타일 변경 */
+.teamCardDeleteBtn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  border-radius: 15%;
+  background-color: var(--color-danger, #CA2937FF);
+  color: white;
+  border: none;
+  font-size: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s, background-color 0.2s;
+  padding: 0;
+}
+
+.teamCardDeleteBtn:hover {
+  opacity: 1;
+  background-color: #c82333;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #58 

## 📝작업 내용
- delete 기능 추가
- delete 를 post 로 처리
    기존 방식의 한계
        - 단순 DELETE API(RESTful DELETE /teams/{id})는 실수·악의적 요청에 의해 즉시 데이터가 영구 삭제되는 문제가 예상되었습니다
        - 한번 삭제되면 복구가 불가능하고, 이건 실제 서비스에서 사용자 경험상 매우 부정적이라고 생각했습니다.
    새로운 전략으로 (소프트 딜리트 + 삭제 스케줄링) 채택
    1. delete 대신 post 
        - 보안 취약점 방지
    2. 즉시 삭제 대신 삭제 예약 상태로 전환
        -  `TeamStatus = MARKED_FOR_DELETE` flag 와 삭제 예정일을 추가
        - 실제 데이터는 남아 있습니다(사용자의 실수를 방지)
    3. 실제 삭제는 스케줄러로 일정기간(지금은 14일 설정) 후에 진행
        - 유예 기간 동안 추후 복구하는 로직을 제공할 여지를 두었습니다.
        - 스케줄링 기간 이후 DB에서 하드 딜리트를 하게 됩니다.
    4. filter 로 삭제된 팀을 팀 목록 불러오기에서 가져올 수 없게 작성했습니다
        - 팀 목록에서 아예 노출이 되지 않게 됩니다.


![image](https://github.com/user-attachments/assets/7261f533-73ab-4b45-bb14-2a61417bb5fb)
![image](https://github.com/user-attachments/assets/f34f3cad-756b-4b50-b258-542161c4ffeb)


## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항
