### PR TITLE
hotfix(Jwt) : JWT인증 불가에 대해서 확인

### DIFF
--- a/Backend/src/main/kotlin/com/luckyseven/backend/core/JwtAuthenticationFilter.kt
+++ b/Backend/src/main/kotlin/com/luckyseven/backend/core/JwtAuthenticationFilter.kt
@@ -31,9 +31,16 @@ class JwtAuthenticationFilter(
     private val logger = LoggerFactory.getLogger(JwtAuthenticationFilter::class.java)
     
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+
         val path = request.requestURI
-        return path.startsWith("/api/users/") || path.startsWith("/api/email/")
-                || path.startsWith("/api/refresh")
+        logger.info("shouldNotFilter 호출됨 - path: $path")  // 디버깅 로그 추가
+
+        val shouldSkip = path.startsWith("/api/users/") ||
+                path.startsWith("/api/email/") ||
+                path == "/api/refresh"
+
+        logger.info("필터 제외 여부: $shouldSkip")  // 디버깅 로그 추가
+        return shouldSkip
     }
     
     @Throws(ServletException::class, IOException::class)

--- a/Frontend/luckeyseven/src/service/ApiService.js
+++ b/Frontend/luckeyseven/src/service/ApiService.js
@@ -157,21 +157,21 @@ export async function postRefreshToken() {
   
   const token = axios.defaults.headers.common['Authorization']?.split(' ')[1];
   
-  // refresh API는 privateApi 사용 (Authorization 헤더 포함, 쿠키도 함께)
-  console.log("=== Refresh API: privateApi 사용 (헤더 + 쿠키) ===");
+  // 서버 환경 문제로 인해 임시로 publicApi 사용 (쿠키만)
+  console.log("=== Refresh API: publicApi 사용 (서버 환경 대응) ===");
   try {
-    const response = await privateApi.post(
+    const response = await publicApi.post(
       '/api/refresh',
       {}, // 빈 body
       {
-        withCredentials: true, // refreshToken 쿠키도 전송
+        withCredentials: true, // refreshToken 쿠키만 전송
         headers: {
           'Content-Type': 'application/json',
         }
       }
     );
     
-    console.log('✅ Refresh API 성공 (privateApi 사용)');
+    console.log('✅ Refresh API 성공 (publicApi 사용 - 서버 대응)');
     console.log('토큰 갱신 응답 상태:', response.status);
     console.log('토큰 갱신 응답 헤더:', JSON.stringify(response.headers));
     
@@ -200,7 +200,7 @@ export async function postRefreshToken() {
     }
     return response;
   } catch (error) {
-    console.error('❌ Refresh API 실패 (privateApi 사용)');
+    console.error('❌ Refresh API 실패 (publicApi 사용 - 서버 대응)');
     console.error('오류 상태:', error.response?.status);
     console.error('오류 데이터:', error.response?.data);
     console.error('전체 오류 객체:', error);

--- a/Frontend/luckeyseven/src/service/AuthService.js
+++ b/Frontend/luckeyseven/src/service/AuthService.js
@@ -285,9 +285,9 @@ export const logout = async() => {
             console.log("=== 로그아웃 API 호출 시작 ===");
             console.log("쿠키 상태:", document.cookie);
             
-            // 로그아웃은 privateApi 사용 (Authorization 헤더 + refreshToken 쿠키)
-            const response = await privateApi.post("/api/users/logout", {}, {
-                withCredentials: true,  // refreshToken 쿠키 전송
+            // 서버 환경 문제로 인해 임시로 publicApi 사용 (쿠키만)
+            const response = await publicApi.post("/api/users/logout", {}, {
+                withCredentials: true,  // refreshToken 쿠키만 전송
                 headers: {
                     'Content-Type': 'application/json',
                 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #이슈 번호
- ex) #17

## 📝작업 내용
- Logout과 refresh에 대해서 헤더에 인증은 필요없고 쿠키만 포함하는 publicApi로 일단 보내볼려고합니다.

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?